### PR TITLE
Update instruction.py

### DIFF
--- a/pydis/instruction.py
+++ b/pydis/instruction.py
@@ -380,10 +380,10 @@ class Instruction:
     def address(self) -> int:
         return self._instruction.instructionAddress
 
-    # TODO double check functionality of this property
     @property
     def accessed_flags(self) -> [CpuFlag]:
-        return [CpuFlag(flag.action) for flag in self._instruction.accessedFlags]
+        """ Return a dict composed by CpuFlag: CpuFlagAction """
+        return {CpuFlag(idx): CpuFlagAction(flag.action) for idx, flag in enumerate(list(i._instruction.accessedFlags))}
 
     @property
     def avx(self) -> InstructionAvx:

--- a/pydis/instruction.py
+++ b/pydis/instruction.py
@@ -1,7 +1,7 @@
 import typing
 
 from .types import (MachineMode, OperandType, OperandVisibility, OperandAction, OperandEncoding, ElementTypes,
-                    MemOpType, InstructionEncoding, OpcodeMap, CpuFlag, MaskModes, BroadcastModes, RoundingModes,
+                    MemOpType, InstructionEncoding, OpcodeMap, CpuFlag, CpuFlagAction, MaskModes, BroadcastModes, RoundingModes,
                     SwizzleModes, ConversionMode, ExceptionClass, InstructionAttribute, Status)
 from .zydis_types import (Instruction as RawInstruction, Operand as RawOperand, OperandMem, OperandPtr, OperandImm,
                           InstructionAvx as RawInstructionAvx, AvxMask as RawAvxMask, AvxBroadcast as RawAvxBroadcast,

--- a/pydis/instruction.py
+++ b/pydis/instruction.py
@@ -383,7 +383,7 @@ class Instruction:
     @property
     def accessed_flags(self) -> [CpuFlag]:
         """ Return a dict composed by CpuFlag: CpuFlagAction """
-        return {CpuFlag(idx): CpuFlagAction(flag.action) for idx, flag in enumerate(list(i._instruction.accessedFlags))}
+        return {CpuFlag(idx): CpuFlagAction(flag.action) for idx, flag in enumerate(list(self._instruction.accessedFlags))}
 
     @property
     def avx(self) -> InstructionAvx:


### PR DESCRIPTION
Hello,

This PR aims at fixing the function `accessed_flags` in `Instruction` class.
Right now it returns a list of `CpuFlag` created from the flag action, and this is quite wrong (see below).
```
>>> i.accessed_flags
[<CpuFlag.ZF: 3>, <CpuFlag.IF: 6>, <CpuFlag.IF: 6>, <CpuFlag.CF: 0>, <CpuFlag.IF: 6>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.IF: 6>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>, <CpuFlag.CF: 0>]
```

With my version, it returns a dict indexed by the CpuFlag, and with the CpuFlagAction as value.
```
>>> i.accessed_flags
{<CpuFlag.CF: 0>: <CpuFlagAction.Modified: 3>, <CpuFlag.PF: 1>: <CpuFlagAction.Undefined: 6>, <CpuFlag.AF: 2>: <CpuFlagAction.Undefined: 6>, <CpuFlag.ZF: 3>: <CpuFlagAction.NoAction: 0>, <CpuFlag.SF: 4>: <CpuFlagAction.Undefined: 6>, <CpuFlag.TF: 5>: <CpuFlagAction.NoAction: 0>, <CpuFlag.IF: 6>: <CpuFlagAction.NoAction: 0>, <CpuFlag.DF: 7>: <CpuFlagAction.NoAction: 0>, <CpuFlag.OF: 8>: <CpuFlagAction.Undefined: 6>, <CpuFlag.IOPL: 9>: <CpuFlagAction.NoAction: 0>, <CpuFlag.NT: 10>: <CpuFlagAction.NoAction: 0>, <CpuFlag.RF: 11>: <CpuFlagAction.NoAction: 0>, <CpuFlag.VM: 12>: <CpuFlagAction.NoAction: 0>, <CpuFlag.AC: 13>: <CpuFlagAction.NoAction: 0>, <CpuFlag.VIF: 14>: <CpuFlagAction.NoAction: 0>, <CpuFlag.VIP: 15>: <CpuFlagAction.NoAction: 0>, <CpuFlag.ID: 16>: <CpuFlagAction.NoAction: 0>, <CpuFlag.C0: 17>: <CpuFlagAction.NoAction: 0>, <CpuFlag.C1: 18>: <CpuFlagAction.NoAction: 0>, <CpuFlag.C2: 19>: <CpuFlagAction.NoAction: 0>, <CpuFlag.C3: 20>: <CpuFlagAction.NoAction: 0>}
```

So it's quite convenient, because now one can do:
```
>>> i.accessed_flags[CpuFlag.ZF]
<CpuFlagAction.NoAction: 0>
```

Thanks.